### PR TITLE
Fixed Suite summary table border issue #2172

### DIFF
--- a/src/main/java/org/testng/reporters/EmailableReporter2.java
+++ b/src/main/java/org/testng/reporters/EmailableReporter2.java
@@ -148,7 +148,7 @@ public class EmailableReporter2 implements IReporter {
 
     int testIndex = 0;
     for (SuiteResult suiteResult : suiteResults) {
-      writer.print("<tr><th colspan=\"7\">");
+      writer.print("<tr><th colspan=\"8\">");
       writer.print(Utils.escapeHtml(suiteResult.getSuiteName()));
       writer.println("</th></tr>");
 


### PR DESCRIPTION
Fixes #2172.

Updated Suite Summary, table header 'colspan' value to '8' from '7'.